### PR TITLE
Potential fix for code scanning alert no. 129: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/emergency-ci-fixes.yml
+++ b/.github/workflows/emergency-ci-fixes.yml
@@ -1,4 +1,6 @@
 name: Emergency CI/CD Fixes
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Trancendos/trancendos-ecosystem/security/code-scanning/129](https://github.com/Trancendos/trancendos-ecosystem/security/code-scanning/129)

The best fix is to add an explicit `permissions` block to the workflow or to the specific jobs so that the GITHUB_TOKEN is only granted the least permissions required. Since there is no indication of write operations in either job, specifying `permissions: contents: read` is likely sufficient. You can do this at the workflow level (recommended so it applies to all jobs unless overridden) by adding a top-level `permissions:` block after the `name:` and before the `jobs:` key.

The changes should be made within `.github/workflows/emergency-ci-fixes.yml`:  
- Insert a block under the workflow name (e.g., after line 1 or 2).
- Specify:
  ```yaml
  permissions:
    contents: read
  ```
This will restrict the GITHUB_TOKEN for all jobs in the workflow to read-only access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
